### PR TITLE
Working around issues with locale - testing hardcode to our default.

### DIFF
--- a/lib/contentful_migrations/migration.rb
+++ b/lib/contentful_migrations/migration.rb
@@ -25,7 +25,11 @@ module ContentfulMigrations
     end
 
     def record_migration(migration_content_type)
-      entry = migration_content_type.entries.create(version: version)
+      entry = migration_content_type.entries.new
+      # Our Contentful space has default (and only) locale of en-GB
+      # we need to set the locale explicitly to store the version
+      entry.locale = 'en-GB'
+      entry.version = version
       entry.save
       entry.publish
       entry

--- a/lib/contentful_migrations/migrator.rb
+++ b/lib/contentful_migrations/migrator.rb
@@ -36,7 +36,10 @@ module ContentfulMigrations
       @logger = logger
       @space_id = space_id
       @migration_content_type_name = migration_content_type_name
-      @client = Contentful::Management::Client.new(access_token)
+      # Our Contentful space has default (and only) locale of en-GB
+      # we need to set the default client locale explicitly otherwise stuff doesn't work...
+      # See https://github.com/contentful/contentful-management.rb/issues/73 and 201 - 204
+      @client = Contentful::Management::Client.new(access_token, default_locale: 'en-GB')
       @env_id = env_id || ENV['CONTENTFUL_ENV'] || 'master'
       @space = @client.environments(space_id).find(@env_id)
       @page_size = 1000


### PR DESCRIPTION
WIP / Spike PR for problem with our locales

Because the default locale for our space is 'en-GB', new entries need to have their content set for that locale, but we also need to set the default_locale for the client to this otherwise entries do not get created and have field data stored...

...not currently sure if this would break anything else in the versioning, etc.