### PR TITLE
Move rails tasks/generators into a Railtie

### DIFF
--- a/lib/contentful_migrations.rb
+++ b/lib/contentful_migrations.rb
@@ -6,4 +6,4 @@ require 'contentful_migrations/migration_proxy'
 require 'contentful_migrations/migration'
 require 'contentful_migrations/migrator'
 
-# load 'tasks/contentful_migrations.rake' if defined?(Rails)
+require 'contentful_migrations/railtie' if defined?(Rails::Railtie)

--- a/lib/contentful_migrations.rb
+++ b/lib/contentful_migrations.rb
@@ -6,4 +6,4 @@ require 'contentful_migrations/migration_proxy'
 require 'contentful_migrations/migration'
 require 'contentful_migrations/migrator'
 
-load 'tasks/contentful_migrations.rake' if defined?(Rails)
+# load 'tasks/contentful_migrations.rake' if defined?(Rails)

--- a/lib/contentful_migrations/railtie.rb
+++ b/lib/contentful_migrations/railtie.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module ContentfulMiagrations
+  class Railtie < Rails::Railtie
+    rake_tasks do
+      load File.join(File.dirname(__FILE__), '..', 'tasks', 'contentful_migrations.rake')
+    end
+
+    generators do
+      require_relative "../generators/contentful_migration_generator"
+    end
+  end
+end

--- a/lib/contentful_migrations/railtie.rb
+++ b/lib/contentful_migrations/railtie.rb
@@ -7,7 +7,7 @@ module ContentfulMiagrations
     end
 
     generators do
-      require_relative "../generators/contentful_migration_generator"
+      require_relative '../generators/contentful_migration/contentful_migration_generator'
     end
   end
 end

--- a/lib/tasks/contentful_migrations.rake
+++ b/lib/tasks/contentful_migrations.rake
@@ -1,17 +1,17 @@
 require 'contentful_migrations'
 namespace :contentful_migrations do
   desc 'Migrate the contentful space, runs all pending migrations'
-  task :migrate, [:contentful_space]  do |_t, _args|
+  task migrate: :environment do |_t, _args|
     ContentfulMigrations::Migrator.migrate
   end
 
   desc 'Rollback previous contentful migration'
-  task :rollback, [:contentful_space] do |_t, _args|
+  task rollback: :environment do |_t, _args|
     ContentfulMigrations::Migrator.rollback
   end
 
   desc 'List any pending contentful migrations'
-  task :pending, [:contentful_space]  do |_t, _args|
+  task pending: :environment  do |_t, _args|
     ContentfulMigrations::Migrator.pending
   end
 end


### PR DESCRIPTION
This is neater, and means the Gem interacts with `rails -T` and `rails generators --list` correctly.

Also in the rake tasks, inherit the `:environment` task, so rails is loaded properly.