### PR TITLE
Find and use the default locale when recording migrations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    contentful-migrations (0.2.0)
+    contentful-migrations (0.2.1)
       contentful-management (~> 3.0)
 
 GEM
@@ -21,7 +21,7 @@ GEM
     docile (1.4.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    ffi (1.15.4)
+    ffi (1.15.5)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake

--- a/contentful-migrations.gemspec
+++ b/contentful-migrations.gemspec
@@ -41,4 +41,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec_junit_formatter'
   spec.add_development_dependency 'rubocop-rspec'
   spec.add_development_dependency 'simplecov'
+  spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/lib/contentful_migrations/migrator.rb
+++ b/lib/contentful_migrations/migrator.rb
@@ -4,7 +4,7 @@ require 'contentful/management/client'
 require 'contentful_migrations/string_refinements'
 
 module ContentfulMigrations
-  class Migrator
+  class Migrator # rubocop:disable Metrics/ClassLength
     using StringRefinements
 
     class InvalidMigrationPath < StandardError # :nodoc:
@@ -33,7 +33,8 @@ module ContentfulMigrations
         migrations_path: ENV.fetch('MIGRATION_PATH', DEFAULT_MIGRATION_PATH),
         access_token: ENV.fetch('CONTENTFUL_MANAGEMENT_ACCESS_TOKEN'),
         space_id: ENV.fetch('CONTENTFUL_SPACE_ID'),
-        migration_content_type_name: ENV.fetch('CONTENTFUL_MIGRATION_CONTENT_TYPE', DEFAULT_MIGRATION_CONTENT_TYPE_NAME),
+        migration_content_type_name: ENV.fetch('CONTENTFUL_MIGRATION_CONTENT_TYPE',
+                                               DEFAULT_MIGRATION_CONTENT_TYPE_NAME),
         logger: Logger.new($stdout)
       }.merge(args)
     end

--- a/lib/contentful_migrations/migrator.rb
+++ b/lib/contentful_migrations/migrator.rb
@@ -148,7 +148,7 @@ module ContentfulMigrations
       ).content_type
 
       # Set the default locale on the content type client (ugh)
-      content_type.client.default_locale = default_locale
+      content_type.client.configuration[:default_locale] = default_locale
 
       @migration_content_type = content_type
     end

--- a/lib/contentful_migrations/migrator.rb
+++ b/lib/contentful_migrations/migrator.rb
@@ -141,9 +141,24 @@ module ContentfulMigrations
     end
 
     def migration_content_type
-      @migration_content_type ||= MigrationContentType.new(
+      return @migration_content_type if @migration_content_type.is_a?(MigrationContentType)
+
+      content_type ||= MigrationContentType.new(
         environment: environment, content_type_name: migration_content_type_name
       ).content_type
+
+      # Set the default locale on the content type client (ugh)
+      content_type.client.default_locale = default_locale
+
+      @migration_content_type = content_type
+    end
+
+    def available_locales
+      @available_locales ||= environment.locales.all
+    end
+
+    def default_locale
+      @default_locale ||= available_locales.find(&:default)
     end
 
     MIGRATION_FILENAME_REGEX = /\A([0-9]+)_([_a-z0-9]*)\.?([_a-z0-9]*)?\.rb\z/.freeze

--- a/lib/contentful_migrations/migrator.rb
+++ b/lib/contentful_migrations/migrator.rb
@@ -62,7 +62,15 @@ module ContentfulMigrations
     end
 
     def environment
-      @environment ||= client.environments(space_id).find(env_id)
+      return @environment if @environment.is_a?(Contentful::Management::Environment)
+
+      env = client.environments(space_id).find(env_id)
+
+      # Set the default locale on the environment's client (ugh)
+      default_locale = env.locales.all.find(&:default)
+      env.client.configuration[:default_locale] = default_locale
+
+      @environment = env
     end
 
     def migrate
@@ -141,24 +149,9 @@ module ContentfulMigrations
     end
 
     def migration_content_type
-      return @migration_content_type if @migration_content_type.is_a?(MigrationContentType)
-
-      content_type ||= MigrationContentType.new(
+      @migration_content_type ||= MigrationContentType.new(
         environment: environment, content_type_name: migration_content_type_name
       ).content_type
-
-      # Set the default locale on the content type client (ugh)
-      content_type.client.configuration[:default_locale] = default_locale
-
-      @migration_content_type = content_type
-    end
-
-    def available_locales
-      @available_locales ||= environment.locales.all
-    end
-
-    def default_locale
-      @default_locale ||= available_locales.find(&:default)
     end
 
     MIGRATION_FILENAME_REGEX = /\A([0-9]+)_([_a-z0-9]*)\.?([_a-z0-9]*)?\.rb\z/.freeze

--- a/lib/contentful_migrations/migrator.rb
+++ b/lib/contentful_migrations/migrator.rb
@@ -68,7 +68,7 @@ module ContentfulMigrations
 
       # Set the default locale on the environment's client (ugh)
       default_locale = env.locales.all.find(&:default)
-      env.client.configuration[:default_locale] = default_locale
+      env.client.configuration[:default_locale] = default_locale.code
 
       @environment = env
     end

--- a/lib/contentful_migrations/version.rb
+++ b/lib/contentful_migrations/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentfulMigrations
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end

--- a/spec/lib/contentful_migrations/migrator_spec.rb
+++ b/spec/lib/contentful_migrations/migrator_spec.rb
@@ -110,6 +110,12 @@ RSpec.describe ContentfulMigrations::Migrator do
         let(:client) { double(:client) }
         let(:spaces) { double(:spaces) }
         let(:space) { double(:space) }
+        let(:locales) { double(:locales) }
+        let(:all_locales) { [default_locale] }
+        let(:default_locale) { Struct.new(:code, :default).new('en', true) }
+        let(:space_client) { double(:space_client) }
+        let(:space_client_config) { {} }
+
         let(:content_types) { double(:content_types) }
         let(:migration_content_type) { double(:migration_content_type) }
         let(:entries) { double(:entries, all: all) }
@@ -125,6 +131,11 @@ RSpec.describe ContentfulMigrations::Migrator do
           expect(Contentful::Management::Client).to receive(:new).and_return(client)
           expect(client).to receive(:environments).with(space_id).and_return(space)
           expect(space).to receive(:find).with(env_id).and_return(space)
+          expect(space).to receive(:locales).and_return(locales)
+          expect(locales).to receive(:all).and_return(all_locales)
+          expect(space).to receive(:client).and_return(space_client)
+          expect(space_client).to receive(:configuration).and_return(space_client_config)
+
           expect(migration_content_type).to receive(:entries).and_return(entries)
           expect(ContentfulMigrations::MigrationProxy).to receive(:new).with(
             'BuildTestContent',
@@ -135,6 +146,7 @@ RSpec.describe ContentfulMigrations::Migrator do
           expect(migration).to receive(:migrate).with(:up, client, space)
           expect(migration).to receive(:record_migration).with(migration_content_type)
           expect(migrator.migrate).to eq(migrator)
+          expect(space_client_config[:default_locale]).to eq default_locale.code
         end
 
         it 'sets @page_size during construction' do

--- a/spec/lib/contentful_migrations/migrator_spec.rb
+++ b/spec/lib/contentful_migrations/migrator_spec.rb
@@ -80,7 +80,6 @@ RSpec.describe ContentfulMigrations::Migrator do
 
     describe '#initialize' do
       it 'sets name and version' do
-
         expect(migrator.migrations_path).to eq migrations_path
         expect(migrator.access_token).to eq access_token
         expect(migrator.space_id).to eq space_id


### PR DESCRIPTION
This asks Contentful for the default locale setting on the environment, before setting it in the environment itself.  Why this can't be done in the Contentful Management client I do not know.